### PR TITLE
Set Minimum API to 15 (Does not cover ripple effects)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,7 +8,7 @@ android {
     compileSdkVersion 27
     defaultConfig {
         applicationId "com.example.aniket.floatingtextbutton"
-        minSdkVersion 21
+        minSdkVersion 15
         targetSdkVersion 27
         versionCode 1
         versionName "1.0"

--- a/mutativefab/build.gradle
+++ b/mutativefab/build.gradle
@@ -11,7 +11,7 @@ android {
 
 
     defaultConfig {
-        minSdkVersion 21
+        minSdkVersion 15
         targetSdkVersion 27
         versionCode 1
         versionName "1.0"

--- a/mutativefab/src/main/java/com/aniket/mutativefloatingactionbutton/MutativeFab.kt
+++ b/mutativefab/src/main/java/com/aniket/mutativefloatingactionbutton/MutativeFab.kt
@@ -3,13 +3,16 @@ package com.aniket.mutativefloatingactionbutton
 import android.content.Context
 import android.content.res.TypedArray
 import android.graphics.PorterDuff
+import android.graphics.drawable.LayerDrawable
+import android.os.Build
 import android.support.annotation.ColorInt
 import android.support.constraint.ConstraintLayout
 import android.support.constraint.ConstraintSet
 import android.support.design.widget.CoordinatorLayout
+import android.support.transition.ChangeBounds
+import android.support.transition.TransitionManager
 import android.support.v4.content.ContextCompat
-import android.transition.ChangeBounds
-import android.transition.TransitionManager
+import android.support.v4.view.ViewCompat
 import android.util.AttributeSet
 import android.view.View
 import android.widget.ImageView
@@ -42,6 +45,7 @@ class MutativeFab @JvmOverloads constructor(
             constraintLayout = findViewById(R.id.constraint_Layout)
             constraintSet1.clone(constraintLayout)
             constraintSet2.clone(context, R.layout.mutative_fab_layout_alt)
+            ViewCompat.setElevation(constraintLayout, 12f)
             isClickable = true
             isFocusable = true
         }
@@ -112,7 +116,15 @@ class MutativeFab @JvmOverloads constructor(
     }
 
     fun setFabBackgroundColor(@ColorInt color: Int) {
-        constraintLayout.background.mutate().setColorFilter(color, PorterDuff.Mode.SRC_ATOP)
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+            if (constraintLayout.background is LayerDrawable) {
+                (constraintLayout.background as LayerDrawable).findDrawableByLayerId(R.id.fab_shape)?.apply {
+                    mutate().setColorFilter(color, PorterDuff.Mode.SRC_ATOP)
+                }
+            }
+        } else {
+            constraintLayout.background.mutate().setColorFilter(color, PorterDuff.Mode.SRC_ATOP)
+        }
     }
 
 

--- a/mutativefab/src/main/res/drawable-v21/fab_background.xml
+++ b/mutativefab/src/main/res/drawable-v21/fab_background.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="#e0e0e0">
+    <item android:id="@+id/fab_shape">
+        <shape xmlns:android="http://schemas.android.com/apk/res/android"
+            android:shape="rectangle">
+            <corners android:radius="30dp" />
+            <solid android:color="@color/colorAccent" />
+        </shape>
+    </item>
+</ripple>

--- a/mutativefab/src/main/res/drawable/fab_background.xml
+++ b/mutativefab/src/main/res/drawable/fab_background.xml
@@ -1,11 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ripple xmlns:android="http://schemas.android.com/apk/res/android"
-    android:color="#e0e0e0">
-    <item android:id="@+id/fab_shape">
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <shape android:shape="rectangle">
+            <corners
+                android:topLeftRadius="@dimen/fab_radius"
+                android:topRightRadius="@dimen/fab_radius"
+                android:bottomRightRadius="@dimen/fab_shadow_radius"
+                android:bottomLeftRadius="@dimen/fab_shadow_radius" />
+            <gradient
+                android:angle="270"
+                android:startColor="@android:color/transparent"
+                android:endColor="@color/shadowEndColor"/>
+        </shape>
+    </item>
+    <item android:id="@+id/fab_shape"
+        android:bottom="1.5dp">
         <shape xmlns:android="http://schemas.android.com/apk/res/android"
             android:shape="rectangle">
-            <corners android:radius="30dp" />
+            <corners android:radius="@dimen/fab_radius" />
             <solid android:color="@color/colorAccent" />
         </shape>
     </item>
-</ripple>
+</layer-list>

--- a/mutativefab/src/main/res/values/colors.xml
+++ b/mutativefab/src/main/res/values/colors.xml
@@ -3,4 +3,6 @@
     <color name="colorPrimary">#3F51B5</color>
     <color name="colorPrimaryDark">#303F9F</color>
     <color name="colorAccent">#FF4081</color>
+
+    <color name="shadowEndColor">#30000000</color>
 </resources>

--- a/mutativefab/src/main/res/values/dimen.xml
+++ b/mutativefab/src/main/res/values/dimen.xml
@@ -2,4 +2,6 @@
 <resources>
     <dimen name="fab_margin">16dp</dimen>
     <dimen name="fab_image_size">36dp</dimen>
+    <dimen name="fab_shadow_radius">24dp</dimen>
+    <dimen name="fab_radius">30dp</dimen>
 </resources>


### PR DESCRIPTION
- Transition related component (ChangeBound, TransitionManager) is now
using support library
- fab_background.xml lives under two directory: drawable and
drawable-v21.
- fake shadow is added
- example app minSDK is changed to 15